### PR TITLE
chore: Build tasks in VSCode

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           export VALHEIM_INSTALL=~/VHINSTALL/
           xbuild JotunnLib.sln /p:Configuration=Release
-          mv JotunnLib/obj/Release/JotunnLib.dll JotunnLib-${{ steps.tag.outputs.result }}.dll
+          mv JotunnLib/obj/Release/JotunnLib.dll JotunnLib.dll
           xbuild JotunnLib.sln /p:Configuration=Debug
           mv JotunnLib/obj/Debug/JotunnLib.dll JotunnLib-DEBUG-${{ steps.tag.outputs.result }}.dll
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 name: Create Release
 
@@ -64,7 +64,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            JotunnLib-${{ steps.tag.outputs.result }}.dll
+            JotunnLib.dll
             JotunnLib-DEBUG-${{ steps.tag.outputs.result }}.dll
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ JotunnLib/Documentation/api
 lib/
 Lib/
 releases/
+
+# VS Code
+.vscode/*
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Release DLL",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                // Ask msbuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                "/property:Configuration=Release",
+                // "/t:build",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                // "/consoleloggerparameters:NoSummary",
+                "JotunnLib.sln"
+            ],
+            "group": "build",
+            // "presentation": {
+            //     // Reveal the output only if unrecognized errors occur.
+            //     "reveal": "silent"
+            // },
+            // Use the standard MS compiler pattern to detect errors, warnings and infos
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build Debug DLL",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                // Ask msbuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                "/property:Configuration=Debug",
+                // "/t:build",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                // "/consoleloggerparameters:NoSummary",
+                "JotunnLib.sln"
+            ],
+            "group": "build",
+            // "presentation": {
+            //     // Reveal the output only if unrecognized errors occur.
+            //     "reveal": "silent"
+            // },
+            // Use the standard MS compiler pattern to detect errors, warnings and infos
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Add support for building in VSCode by using the build command palette (`Ctrl`+`Shift`+`b`).

Changelog:
- Created `.vscode/tasks.json`
- Gitignored `.vscode` except `tasks.json`