### PR TITLE
fix: Potential severe skill registration bug

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,13 +13,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Extract tag name
-        id: tag
-        uses: actions/github-script@0.2.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            return context.payload.ref.replace(/\/refs\/tags\//, '');
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
@@ -39,7 +35,7 @@ jobs:
       - name: Get build commands
         run: |
           sudo apt-get update
-          sudo apt-get install -y git mono-complete mono-xbuild unzip
+          sudo apt-get install -y mono-complete mono-xbuild unzip
 
       # Prepare Valheim dependencies
       - name: Prepare Valheim dependencies
@@ -58,13 +54,13 @@ jobs:
           xbuild JotunnLib.sln /p:Configuration=Release
           mv JotunnLib/obj/Release/JotunnLib.dll JotunnLib.dll
           xbuild JotunnLib.sln /p:Configuration=Debug
-          mv JotunnLib/obj/Debug/JotunnLib.dll JotunnLib-DEBUG-${{ steps.tag.outputs.result }}.dll
+          mv JotunnLib/obj/Debug/JotunnLib.dll JotunnLib-DEBUG-${{ steps.get_version.outputs.VERSION }}.dll
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             JotunnLib.dll
-            JotunnLib-DEBUG-${{ steps.tag.outputs.result }}.dll
+            JotunnLib-DEBUG-${{ steps.get_version.outputs.VERSION }}.dll
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -14,6 +14,7 @@ namespace JotunnLib.Managers
         public static SkillManager Instance { get; private set; }
 
         internal Dictionary<Skills.SkillType, Skills.SkillDef> Skills = new Dictionary<Skills.SkillType, Skills.SkillDef>();
+        // FIXME: Deprecate
         private int nextSkillId = 1000;
         private void Awake()
         {
@@ -27,6 +28,36 @@ namespace JotunnLib.Managers
         }
 
         /// <summary>
+        /// Configuration class for custom skills
+        /// </summary>
+        public class SkillConfig
+        {
+            public string Identifier
+            {
+                get { return Identifier; }
+                set
+                {
+                    Identifier = value;
+                    UID = value.GetStableHashCode();
+                }
+            }
+            public int UID { get; private set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public Sprite Icon { get; set; }
+            public float IncreaseStep { get; set; }
+
+            // BaseSkill and JSON support targets v0.2.0
+            //private Skills.SkillType BaseSkill { get; set; }
+            //private static SkillConfig FromJson(string json)
+            //{
+            //    return null; // TODO: Make this work
+            //}
+        }
+
+        /// <summary>
+        /// DEPRECATED DUE TO POSSIBLE CONFLICT ISSUE, see: <see href="https://github.com/jotunnlib/jotunnlib/issues/18">GitHub Issue</see>
+        /// <para/>
         /// Register a new skill with given parameters, and registers translations for it in the current localization
         /// </summary>
         /// <param name="name">Name of the new skill</param>
@@ -34,6 +65,7 @@ namespace JotunnLib.Managers
         /// <param name="increaseStep"></param>
         /// <param name="icon">Icon for the skill</param>
         /// <returns>The SkillType of the newly registered skill</returns>
+        [System.Obsolete("Use `RegisterSkill(SkillConfig config)` instead. This method could potentially break user saves.", true)]
         public Skills.SkillType RegisterSkill(string name, string description, float increaseStep = 1f, Sprite icon = null)
         {
             LocalizationManager.Instance.RegisterTranslation("skill_" + nextSkillId, name);
@@ -51,6 +83,49 @@ namespace JotunnLib.Managers
             nextSkillId++;
 
             return skillDef.m_skill;
+        }
+
+        /// <summary>
+        /// Register a new skill with given SkillConfig object, and registers translations for it in the current localization
+        /// </summary>
+        /// <param name="skillConfig">SkillConfig object representing new skill to register</param>
+        /// <returns>The SkillType of the newly registered skill</returns>
+        public Skills.SkillType RegisterSkill(SkillConfig skillConfig)
+        {
+            LocalizationManager.Instance.RegisterTranslation("skill_" + skillConfig.UID, skillConfig.Name);
+            LocalizationManager.Instance.RegisterTranslation("skill_" + skillConfig.UID + "_description", skillConfig.Description);
+
+            Skills.SkillDef skillDef = new Skills.SkillDef()
+            {
+                m_skill = (Skills.SkillType)skillConfig.UID,
+                m_description = "$skill_" + skillConfig.UID + "_description",
+                m_increseStep = skillConfig.IncreaseStep,
+                m_icon = skillConfig.Icon
+            };
+
+            Skills.Add((Skills.SkillType)skillConfig.UID, skillDef);
+            return skillDef.m_skill;
+        }
+
+        /// <summary>
+        /// Register a new skill with given parameters, and registers translations for it in the current localization
+        /// </summary>
+        /// <param name="identifer">Unique identifier of the new skill, ex: "com.jotunnlib.testmod.testskill"</param>
+        /// <param name="name">Name of the new skill</param>
+        /// <param name="description">Description of the new skill</param>
+        /// <param name="increaseStep"></param>
+        /// <param name="icon">Icon for the skill</param>
+        /// <returns>The SkillType of the newly registered skill</returns>
+        public Skills.SkillType RegisterSkill(string identifer, string name, string description, float increaseStep = 1f, Sprite icon = null)
+        {
+            return RegisterSkill(new SkillConfig()
+            {
+                Identifier = identifer,
+                Name = name,
+                Description = description,
+                IncreaseStep = increaseStep,
+                Icon = icon
+            });
         }
 
         /// <summary>
@@ -80,6 +155,16 @@ namespace JotunnLib.Managers
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets a custom skill with given skill identifier
+        /// </summary>
+        /// <param name="identifier">String indentifer of SkillType to look for</param>
+        /// <returns>Custom skill with given SkillType</returns>
+        public Skills.SkillDef GetSkill(string identifier)
+        {
+            return GetSkill((Skills.SkillType)identifier.GetStableHashCode());
         }
     }
 }

--- a/JotunnLib/Managers/SkillManager.cs
+++ b/JotunnLib/Managers/SkillManager.cs
@@ -32,16 +32,17 @@ namespace JotunnLib.Managers
         /// </summary>
         public class SkillConfig
         {
+            private string _identifier;
             public string Identifier
             {
-                get { return Identifier; }
+                get { return this._identifier; }
                 set
                 {
-                    Identifier = value;
-                    UID = value.GetStableHashCode();
+                    this._identifier = value;
+                    UID = (Skills.SkillType)value.GetStableHashCode();
                 }
             }
-            public int UID { get; private set; }
+            public Skills.SkillType UID { get; private set; }
             public string Name { get; set; }
             public string Description { get; set; }
             public Sprite Icon { get; set; }

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -8,7 +8,6 @@ using JotunnLib.Entities;
 using JotunnLib.Managers;
 using JotunnLib.Utils;
 using TestMod.Prefabs;
-using static JotunnLib.Managers.SkillManager;
 
 namespace TestMod
 {

--- a/TestMod/TestMod.cs
+++ b/TestMod/TestMod.cs
@@ -8,6 +8,7 @@ using JotunnLib.Entities;
 using JotunnLib.Managers;
 using JotunnLib.Utils;
 using TestMod.Prefabs;
+using static JotunnLib.Managers.SkillManager;
 
 namespace TestMod
 {
@@ -134,7 +135,7 @@ namespace TestMod
             // Test adding a skill with a texture
             Texture2D testSkillTex = AssetUtils.LoadTexture("TestMod/Assets/test_skill.jpg");
             Sprite testSkillSprite = Sprite.Create(testSkillTex, new Rect(0f, 0f, testSkillTex.width, testSkillTex.height), Vector2.zero);
-            TestSkillType = SkillManager.Instance.RegisterSkill("Testing", "A nice testing skill", 1, testSkillSprite);
+            TestSkillType = SkillManager.Instance.RegisterSkill("com.jotunnlib.testmod.testskill", "Testing Skill", "A nice testing skill!", 1f, testSkillSprite);
         }
     }
 }


### PR DESCRIPTION
Deprecates old `RegisterSkill` method in favour for one that mandates a unique identifier for each skill. Previously, it was possible to skills to be loaded out of order and to be unexpectedly assigned the incorrect identifier. These changes also set up JotunnLib to merge SkillInjector in the near future. Closes #18 

Changelog:
- Deprecated `RegisterSkill(string name, string description, float increaseStep = 1f, Sprite icon = null)`
- Added `SkillConfig` class to store custom skill information
- Added new register and get skill methods to support `SkillConfig` implementations