### PR TITLE
fix: Added checks to ensure pieces and items are in the correct layer

### DIFF
--- a/JotunnLib/JotunnLib.cs
+++ b/JotunnLib/JotunnLib.cs
@@ -13,7 +13,7 @@ namespace JotunnLib
     internal class JotunnLib : BaseUnityPlugin
     {
         // Version
-        public const string Version = "0.1.1";
+        public const string Version = "0.1.3";
 
         // Load order for managers
         private readonly List<Type> managerTypes = new List<Type>()

--- a/JotunnLib/Managers/ObjectManager.cs
+++ b/JotunnLib/Managers/ObjectManager.cs
@@ -59,16 +59,34 @@ namespace JotunnLib.Managers
             ReflectionUtils.InvokePrivate(ObjectDB.instance, "UpdateItemHashes");
         }
 
+        /// <summary>
+        /// Registers a new item from given prefab name
+        /// </summary>
+        /// <param name="prefabName">Name of prefab to use for item</param>
         public void RegisterItem(string prefabName)
         {
             Items.Add(PrefabManager.Instance.GetPrefab(prefabName));
         }
 
+        /// <summary>
+        /// Registers new item from given GameObject. GameObject MUST be also registered as a prefab
+        /// </summary>
+        /// <param name="item">GameObject to use for item</param>
         public void RegisterItem(GameObject item)
         {
+            // Set layer if not already set
+            if (item.layer == 0)
+            {
+                item.layer = LayerMask.NameToLayer("item");
+            }
+
             Items.Add(item);
         }
 
+        /// <summary>
+        /// Registers a new recipe
+        /// </summary>
+        /// <param name="recipeConfig">Recipe details</param>
         public void RegisterRecipe(RecipeConfig recipeConfig)
         {
             Recipe recipe = recipeConfig.GetRecipe();
@@ -84,11 +102,22 @@ namespace JotunnLib.Managers
 
         public void RegisterRecipe(Recipe recipe)
         {
+            if (recipe == null)
+            {
+                Debug.LogError("Failed to add null recipe");
+                return;
+            }
+
             Recipes.Add(recipe);
         }
 
         public GameObject GetItemPrefab(string name)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
             return ObjectDB.instance.GetItemPrefab(name);
         }
 

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -36,7 +36,6 @@ namespace JotunnLib.Managers
         {
             PieceTableContainer = new GameObject("PieceTables");
             PieceTableContainer.transform.parent = JotunnLib.RootObject.transform;
-            UnityEngine.Object.DontDestroyOnLoad(PieceTableContainer);
 
             Debug.Log("Initialized PieceTableManager");
         }

--- a/JotunnLib/Managers/PieceManager.cs
+++ b/JotunnLib/Managers/PieceManager.cs
@@ -99,7 +99,7 @@ namespace JotunnLib.Managers
         {
             if (pieceTables.ContainsKey(name))
             {
-                Debug.Log("Cannot register piece table with existing name" + name);
+                Debug.Log("Failed to register piece table with existing name: " + name);
                 return;
             }
 
@@ -112,41 +112,47 @@ namespace JotunnLib.Managers
 
         public void RegisterPiece(string pieceTable, string prefabName)
         {
-            PieceTable table = getPieceTable(pieceTable);
             GameObject prefab = PrefabManager.Instance.GetPrefab(prefabName);
-
-            if (!table)
-            {
-                Debug.LogError("Piece table does not exist: " + pieceTable);
-                return;
-            }
 
             if (!prefab)
             {
-                Debug.LogError("Prefab does not exist: " + prefabName);
+                Debug.LogError("Failed to register Piece with invalid prefab: " + prefabName);
                 return;
             }
 
-            if (!prefab.GetComponent<Piece>())
-            {
-                Debug.LogError("Prefab does not have Piece component: " + prefabName);
-                return;
-            }
-
-            table.m_pieces.Add(prefab);
-            Debug.Log("Registered piece: " + prefabName + " to " + pieceTable);
+            RegisterPiece(pieceTable, prefab);
         }
 
         internal void RegisterPiece(string pieceTable, GameObject prefab)
         {
             PieceTable table = getPieceTable(pieceTable);
 
+            // Error checking
             if (!table)
             {
-                Debug.LogError("Piece table does not exist: " + pieceTable);
+                Debug.LogError("Failed to register piece, Piece table does not exist: " + pieceTable);
                 return;
             }
 
+            if (!prefab)
+            {
+                Debug.LogError("Failed to register Piece with null prefab");
+                return;
+            }
+
+            if (!prefab.GetComponent<Piece>())
+            {
+                Debug.LogError("Failed to register piece, Prefab does not have Piece component: " + prefab.name);
+                return;
+            }
+
+            // Set layer if not already set
+            if (prefab.layer == 0)
+            {
+                prefab.layer = LayerMask.NameToLayer("piece");
+            }
+
+            // Add prefab
             table.m_pieces.Add(prefab);
             Debug.Log("Registered piece: " + prefab.name + " to " + pieceTable);
         }

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -34,7 +34,6 @@ namespace JotunnLib.Managers
             PrefabContainer = new GameObject("Prefabs");
             PrefabContainer.transform.parent = JotunnLib.RootObject.transform;
             PrefabContainer.SetActive(false);
-            UnityEngine.Object.DontDestroyOnLoad(PrefabContainer);
 
             Debug.Log("Initialized PrefabManager");
         }

--- a/JotunnLib/Managers/PrefabManager.cs
+++ b/JotunnLib/Managers/PrefabManager.cs
@@ -120,9 +120,15 @@ namespace JotunnLib.Managers
         /// <returns></returns>
         public GameObject CreatePrefab(string name)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                Debug.LogError("Failed to create prefab with invalid name: " + name);
+                return null;
+            }
+
             if (GetPrefab(name))
             {
-                Debug.LogError("Prefab already exists: " + name);
+                Debug.LogError("Failed to create prefab, name already exists: " + name);
                 return null;
             }
 
@@ -146,9 +152,15 @@ namespace JotunnLib.Managers
         /// <returns>New prefab object</returns>
         public GameObject CreatePrefab(string name, string baseName)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                Debug.LogError("Failed to create prefab with invalid name: " + name);
+                return null;
+            }
+
             if (GetPrefab(name))
             {
-                Debug.LogError("Prefab already exists: " + name);
+                Debug.LogError("Failed to create prefab, name already exists: " + name);
                 return null;
             }
 
@@ -156,7 +168,7 @@ namespace JotunnLib.Managers
 
             if (!prefabBase)
             {
-                Debug.LogError("Prefab base does not exist: " + baseName);
+                Debug.LogError("Failed to create prefab, base does not exist: " + baseName);
                 return null;
             }
 
@@ -175,6 +187,11 @@ namespace JotunnLib.Managers
         /// <returns></returns>
         public GameObject GetPrefab(string name)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
             if (Prefabs.ContainsKey(name))
             {
                 return Prefabs[name];
@@ -186,12 +203,12 @@ namespace JotunnLib.Managers
                 return null;
             }
 
-            foreach (GameObject obj in ZNetScene.instance.m_prefabs)
+            var namedPrefabs = ReflectionUtils.GetPrivateField<Dictionary<int, GameObject>>(ZNetScene.instance, "m_namedPrefabs");
+            int key = name.GetStableHashCode();
+
+            if (namedPrefabs.ContainsKey(key))
             {
-                if (obj.name == name)
-                {
-                    return obj;
-                }
+                return namedPrefabs[key];
             }
 
             return null;


### PR DESCRIPTION
Changelog:
- Added extra checks to ensure invalid objects or prefabs will not be created
- Added check to ensure that pieces and items are placed in the correct layer
- Fixed Unity warning about non-root objects not being able to be set to not destroy on load
- Documented functionality in ObjectManager